### PR TITLE
[Conflict] Hardcoded cupy-cuda12x dependency breaks support for RTX 5090 (CUDA 13)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 opencv-python
 numpy
 pillow
-cupy-cuda12x>=13.3.0
+cupy-cuda12x
 timm
 omegaconf
 yacs


### PR DESCRIPTION
System Information:

OS: Windows 11

GPU: NVIDIA GeForce RTX 5090 (24GB)

CUDA Version: 13.x

ComfyUI Version: v0.11.1

Python: 3.12.10

Description: I am reporting a critical dependency conflict caused by the hardcoded requirement for cupy-cuda12x in requirements.txt.

Since I am using an RTX 5090, my environment requires CUDA 13 and cupy-cuda13x. However, this node enforces the installation of cupy-cuda12x every time ComfyUI starts or updates.

This results in a "Double Install" conflict where both cupy-cuda12x and cupy-cuda13x are present in the site-packages, causing the following error and instability:

Plaintext
UserWarning: CuPy may not function correctly because multiple CuPy packages are installed in your environment:
  cupy-cuda12x, cupy-cuda13x
Steps to Reproduce:

Setup an environment with cupy-cuda13x (for CUDA 13/RTX 5090).

Install/Update this node.

The node automatically pip installs cupy-cuda12x.

The environment is now broken due to package conflict.

Suggested Fix: Please consider removing cupy-cuda12x from requirements.txt or making it optional. Ideally, the node should check if any version of cupy is already installed (e.g., cupy-cuda11x, 12x, or 13x) and respect the user's existing configuration, rather than forcing a specific CUDA version that may be incompatible with newer hardware.

Thank you!